### PR TITLE
refactor: 공통컴포넌트 input border-radius 수정#21

### DIFF
--- a/pages/components/common/Input.tsx
+++ b/pages/components/common/Input.tsx
@@ -20,6 +20,8 @@ const Input: React.FC<InputProps> = ({
   label,
   size = 'login',
 }) => {
+  const borderRadius = size === 'search' ? '50px' : '16px';
+
   return (
     <div className={styles.inputContainer}>
       {label && <label className={styles.label}>{label}</label>}
@@ -38,6 +40,7 @@ const Input: React.FC<InputProps> = ({
         value={value}
         onChange={onChange}
         className={`${styles.input} ${styles[size]} ${type === 'search' ? styles.search : ''}`}
+        style={{ borderRadius }}
       />
     </div>
   );


### PR DESCRIPTION
현재 input border-radius가 동일하여 figma 시안에 따라 로그인에 쓰이는 input은 16px, 검색창 input은 50px로 수정하였습니다.

사용방법은 그대로입니다! 