### PR TITLE
refactor: wine-list page 반응형 처리 useDevice 훅을 이용한 처리 

### DIFF
--- a/pages/wines.module.css
+++ b/pages/wines.module.css
@@ -3,6 +3,15 @@
   height: auto;
   margin: 0 auto;
   margin-top: 44px;
+  min-height: 1500px;
+}
+
+.winesContainer_tablet {
+  width: 704px;
+}
+
+.winesContainer_mobile {
+  width: 343px;
 }
 
 .winesRecommend {
@@ -13,12 +22,27 @@
   overflow: hidden;
 }
 
+.winesRecommend_mobile {
+  height: 241px;
+  border-radius: 12px;
+}
+
 .wines_list {
   width: 800px;
-  height: 417px;
+  height: 417px; /* 417*/
   margin-top: 20px;
   display: block; /* flex -> flex-end로 주니깐 내부 map이 생길때 밀림현상 발생하여 block 처리 후, 개별적으로 탑마진처리*/
   margin-left: 340px;
+}
+
+.wines_list_tablet {
+  width: 707px;
+  margin-left: 0px;
+}
+
+.wines_list_mobile {
+  width: 343px;
+  margin-left: 0px;
 }
 
 .wines_listMap {
@@ -30,17 +54,56 @@
   margin-top: 42px; /* block 처리 후 탑 마진처리 */
 }
 
+
+.wines_listMap_mobile {
+  height: 360px;
+  border-radius: 12px;
+  margin-top: 57px; /* block 처리 후 탑 마진처리 */
+}
+
 .winesFilter {
   width: 284px;
-  height: 628px;
-  background-color: wheat;
+  height: 578px;
   position: relative;
   top: -375px; /* 400 */
+  background-color: aquamarine;
+}
+
+.winesFilter_tablet {
+  width: 48px;
+  height: 48px;
+  top: -485px;
+}
+
+.winesFilter_mobile {
+  width: 38px;
+  height: 38px;
+  top: -418px;
 }
 
 .custom_input_wrapper {
   margin-top: 40px;
   margin-left: 340px;
+}
+
+.custom_input_wrapper_tablet input {
+  height: 48px;
+  width: 396px;
+}
+
+.custom_input_wrapper_tablet {
+  margin-top: 40px;
+  margin-left: 72px;
+}
+
+.custom_input_wrapper_mobile {
+  margin-top: 24px;
+  margin-left: 0px;
+}
+
+.custom_input_wrapper_mobile input {
+  height: 38px;
+  width: 343px;
 }
 
 .wines_listMapContainer {
@@ -51,13 +114,24 @@
   gap: 20px;
 }
 
+.wines_listMapContainer_mobile {
+  gap: 0px;
+}
+
 .wines_listMapDetailContainer {
-  width: 800px;
+  width: 100%px;
   height: 248px;
   border-bottom: 1px solid var(--gray200);
   display: flex;
   align-items: flex-end;
 }
+
+.wines_listMapDetailContainer_mobile {
+  height: 240px;
+  display: flex;
+  align-items: flex-end;
+}
+
 .wines_listMapDetail {
   height: 211.5px;
   width: 690px;
@@ -66,11 +140,27 @@
   margin-left: 60px;
 }
 
-.wines_listMapReviewContianer {
+.wines_listMapDetail_tablet {
+  width: 624px;
+  gap: 49px;
+  margin-left: 40px;
+}
+
+.wines_listMapDetail_mobile {
+  width: 303px;
+  gap: 36px;
+  margin-left: 20px;
+}
+
+.wines_listMapReviewContainer {
   height: 127px;
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.wines_listMapReviewContainer_mobile {
+  height: 120px;
 }
 
 .wines_listMapReview {
@@ -79,6 +169,17 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+
+}
+
+.wines_listMapReview_tablet {
+  width: 624px;
+}
+
+.wines_listMapReview_mobile {
+  width: 303px;
+  height: 104px;
+  gap: 8px;
 }
 
 .wines_listMapReviewTitle {
@@ -87,10 +188,25 @@
   height: 26px;
 }
 
+.wines_listMapReviewTitle_mobile {
+  width: 52px;
+  height: 24px;
+  font-size: 14px;
+  list-style: 24px;
+}
+
 .wines_listMapReviewContent {
   width: 100%;
   height: 52px;
   color: var(--gray500);
+}
+
+.wines_listMapReviewContent {
+  height: 52px;
+}
+
+.wines_listMapReviewContent_mobile {
+  height: 72px;
 }
 
 .wines_listMapDetailImg {
@@ -102,16 +218,55 @@
   align-items: center;
 }
 
+.wines_listMapDetailImg_mobile {
+  width: 70px;
+  height: 212px;
+  margin-top: 0px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.wines_listMapDetailImg_tablet {
+  width: 74px;
+  height: 208px;
+  margin-top: 3px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+}
+
 .wines_listMapDetailImg img {
   width: 100%;
   margin-top: 2.5px;
 }
 
-.wines_listMapDetailContnet {
+.wines_listMapDetailImg_tablet img {
+  width: 100%;
+  margin-top: -10px;
+}
+
+.wines_listMapDetailContent {
   width: 549px;
   height: 188px;
   display: flex;
   flex-direction: column;
+  gap: 16px;
+  
+}
+
+.wines_listMapDetailContent_mobile {
+  width: 187px;
+  height: 125px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wines_listMapDetailContent_tablet {
+  width: 503px;
   gap: 16px;
 }
 
@@ -123,17 +278,35 @@
   align-items: center;
 }
 
-.wines_listMapDetailContentPrice {
-  width: 100%;
-  height: 42px;
+.wines_listMapDetailContentData_mobile {
+  height: 88px;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
+.wines_listMapDetailContentPrice {
+  width: 100%;
+  height: 42px;
+}
+
+.wines_listMapDetailContentPrice_mobile {
+  width: 100%;
+  height: 29px;
+}
+
 .ContentPriceBtn {
   width: 36px;
   height: 36px;
+}
+
+.ContentPriceBtn_mobile {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  position: relative;
+  top: 26px;
+  left: 165px;
 }
 
 .ContentPrice {
@@ -147,12 +320,30 @@
   align-items: center;
 }
 
+.ContentPrice_mobile {
+  width: 86px;
+  height: 29px;
+  border-radius: 10px;
+  font-size: 14px;
+  line-height: 26px;
+}
+
 .ContentTitleAndFrom {
   width: 300px;
   height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+}
+
+.ContentTitleAndFrom {
+  width: 300px;
+  height: 100%;
+}
+
+.ContentTitleAndFrom_mobile {
+  width: 187px;
+  height: 100%;
 }
 
 .ContentRating {
@@ -163,9 +354,29 @@
   gap: 10px;
 }
 
+.ContentRating_mobile {
+  width: 130px;
+  height: 37px;
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  margin-top: 245px;
+  margin-left: -200px;
+  position: relative;
+  left: -58px;
+}
+
 .ContentTitle {
   height: 84px;
   width: 300px;
+}
+
+.ContentTitle_mobile {
+  height: 64px;
+  width: 187px;
+  font-weight: 600;
+  line-height: 32px;
+  font-size: 20px;
 }
 
 .ContentFrom {
@@ -173,6 +384,15 @@
   width: 198px;
   color: var(--gray500);
 }
+
+.ContentFrom_mobile {
+  height: 24px;
+  width: 187px;
+  font-weight: 400;
+  line-height: 24px;
+  font-size: 14px;
+}
+
 .ContentRatingNumber {
   width: 76px;
   height: 57px;
@@ -181,10 +401,29 @@
   line-height: 57.28px;
 }
 
+.ContentRatingNumber_mobile {
+  width: 45px;
+  height: 33px;
+  font-size: 28px;
+  line-height: 33.41px;
+}
+
 .ContentRatingTotal {
   width: 100px;
   height: 24px;
   color: var(--gray500);
+}
+
+.ContentRatingTotal_mobile {
+  width: 59px;
+  height: 18px;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  position: relative;
+  left: -80px;
+  top: 19px;
+  white-space: nowrap;
 }
 
 .winesRecommendText {
@@ -199,11 +438,31 @@
   padding-top: 30px;
 }
 
+.winesRecommendText_mobile {
+  width: 122px;
+  height: 21px;
+  margin-left: 20px;
+  font-size: 18px;
+  line-height: 21.48px;
+  white-space: nowrap;
+  position: relative;
+  padding-top: 20px;
+}
+
 .winesRecommendSlide {
   height: 185px;
   width: 1200px;
   margin-top: 60px;
   margin-left: 30px;
+  display: flex;
+  gap: 15px;
+}
+
+.winesRecommendSlide_mobile {
+  height: 160px;
+  width: 1200px;
+  margin-top: 40px;
+  margin-left: 20px;
   display: flex;
   gap: 15px;
 }
@@ -219,9 +478,21 @@
   justify-content: center;
 }
 
+.winesRecommendSlideMap_mobile {
+  width: 193px;
+  height: 160px;
+}
+
 .winesRecommendSlideInner {
   width: 172px;
   height: 161px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.winesRecommendSlideInner_mobile {
+  width: 143px;
+  height: 136px;
   display: flex;
   justify-content: space-between;
 }
@@ -233,9 +504,21 @@
   justify-content: center;
 }
 
+.winesRecommendSlideImg_mobile {
+  width: 38px;
+  height: 136px;
+  display: flex;
+  justify-content: center;
+}
+
 .winesRecommendSlideData {
   width: 100px;
   height: 125px;
+}
+
+.winesRecommendSlideData_mobile {
+  width: 80px;
+  height: 97px;
 }
 
 .winesRecommendSlideImg img {
@@ -250,7 +533,12 @@
   gap: 5px;
 }
 
-.RecommnedContentRaitingNumber {
+.RecommendContentRating_mobile {
+  width: 80px;
+  height: 97px;
+}
+
+.RecommendContentRatingNumber {
   width: 57px;
   height: 43px;
   font-weight: 800;
@@ -258,14 +546,54 @@
   line-height: 42.96px;
 }
 
+.RecommendContentRatingNumber_mobile {
+  width: 45px;
+  height: 33px;
+  font-weight: 800;
+  font-size: 28px;
+  line-height: 33.41px;
+}
+
 .RecommendContentRatingText {
   width: 100%;
   height: 54px;
   color: var(--gray500);
-  word-wrap: break-word; 
+  word-wrap: break-word;
+}
+
+.RecommendContentRatingText_mobile {
+  height: 42px;
+  font-weight: 400;
+  font-size: 10px;
+  line-height: 14px;
 }
 
 .starRatingContainer {
-    height: 18px;
-    width: 90px;
+  height: 18px;
+  width: 90px;
+}
+
+.starRatingContainer_mobile {
+  height: 12px;
+  width: 60px;
+}
+
+.winesFilterBtn {
+  width: 284px;
+  height: 50px;
+  background-color: yellow;
+  position: relative;
+  top: -375px;
+}
+
+.winesFilterBtn_tablet {
+  width: 220px;
+  height: 48px;
+  background-color: blue;
+  top: -535px;
+  left: 485px;
+}
+
+.winesFilterBtn_mobile {
+  display: none;
 }

--- a/pages/wines.module.css
+++ b/pages/wines.module.css
@@ -298,6 +298,13 @@
 .ContentPriceBtn {
   width: 36px;
   height: 36px;
+  position: relative;
+  top: -40px;
+  left: 520px;
+}
+
+.ContentPriceBtn_tablet {
+  left: 47g0px;
 }
 
 .ContentPriceBtn_mobile {

--- a/pages/wines.module.css
+++ b/pages/wines.module.css
@@ -51,7 +51,7 @@
   gap: 20px;
 }
 
-.wines_lisMapDetailContainer {
+.wines_listMapDetailContainer {
   width: 800px;
   height: 248px;
   border-bottom: 1px solid var(--gray200);
@@ -66,7 +66,7 @@
   margin-left: 60px;
 }
 
-.wines_lisMapReviewContianer {
+.wines_listMapReviewContianer {
   height: 127px;
   display: flex;
   justify-content: center;
@@ -199,7 +199,7 @@
   padding-top: 30px;
 }
 
-.wineRecommendSlide {
+.winesRecommendSlide {
   height: 185px;
   width: 1200px;
   margin-top: 60px;
@@ -208,7 +208,7 @@
   gap: 15px;
 }
 
-.wineRecommendSlideMap {
+.winesRecommendSlideMap {
   width: 232px;
   height: 185px;
   background-color: white;
@@ -219,26 +219,26 @@
   justify-content: center;
 }
 
-.wineRecoomnedSlideInner {
+.winesRecommendSlideInner {
   width: 172px;
   height: 161px;
   display: flex;
   justify-content: space-between;
 }
 
-.wineRecommendSlideImg {
+.winesRecommendSlideImg {
   width: 44px;
   height: 161px;
   display: flex;
   justify-content: center;
 }
 
-.wineRecommendSlideData {
+.winesRecommendSlideData {
   width: 100px;
   height: 125px;
 }
 
-.wineRecommendSlideImg img {
+.winesRecommendSlideImg img {
   height: 100%;
 }
 
@@ -265,7 +265,7 @@
   word-wrap: break-word; 
 }
 
-.starRatingContiner {
+.starRatingContainer {
     height: 18px;
     width: 90px;
 }

--- a/pages/wines.tsx
+++ b/pages/wines.tsx
@@ -3,8 +3,10 @@ import styles from './wines.module.css';
 import Header from '@/components/layout/Header';
 import Input from '@/components/common/Input';
 import StarRating from '@/components/common/StarRating';
+import useDevice from '@/hooks/useDevice';
 
 const Wines: React.FC = () => {
+  const { mode } = useDevice();
   const wineList = [
     {
       id: 1,
@@ -33,23 +35,49 @@ const Wines: React.FC = () => {
   return (
     <>
       <Header />
-      <div className={styles.winesContainer}>
-        <div className={styles.winesRecommend}>
-          <p className={styles.winesRecommendText}>이번 달 추천 와인</p>
-          <div className={styles.wineRecommendSlide}>
-            <div className={styles.wineRecommendSlideMap}>
-              <div className={styles.wineRecoomnedSlideInner}>
-                <div className={styles.wineRecommendSlideImg}>
+      <div
+        className={`${styles.winesContainer} ${styles[`winesContainer_${mode}`]}`}
+      >
+        <div
+          className={`${styles.winesRecommend} ${styles[`winesRecommend_${mode}`]}`}
+        >
+          <p
+            className={`${styles.winesRecommendText} ${styles[`winesRecommendText_${mode}`]}`}
+          >
+            이번 달 추천 와인
+          </p>
+          <div
+            className={`${styles.winesRecommendSlide} ${styles[`winesRecommendSlide_${mode}`]}`}
+          >
+            <div
+              className={`${styles.winesRecommendSlideMap} ${styles[`winesRecommendSlideMap_${mode}`]}`}
+            >
+              <div
+                className={`${styles.winesRecommendSlideInner} ${styles[`winesRecommendSlideInner_${mode}`]}`}
+              >
+                <div
+                  className={`${styles.winesRecommendSlideImg} ${styles[`winesRecommendSlideImg_${mode}`]}`}
+                >
                   <img src="/images/testWine.svg" alt="와인 이미지" />
                 </div>
-                <div className={styles.wineRecommendSlideData}>
-                  <div className={styles.RecommendContentRating}>
-                    <p className={styles.RecommnedContentRaitingNumber}>4.8</p>
-                    <div className={styles.starRatingContiner}>
+                <div
+                  className={`${styles.winesRecommendSlideData} ${styles[`winesRecommendSlideData_${mode}`]}`}
+                >
+                  <div
+                    className={`${styles.RecommendContentRating} ${styles[`RecommendContentRating_${mode}`]}`}
+                  >
+                    <p
+                      className={`${styles.RecommnedContentRaitingNumber} ${styles[`RecommendContentRatingNumber_${mode}`]}`}
+                    >
+                      4.8
+                    </p>
+                    <div
+                      className={`${styles.starRatingContainer} ${styles[`starRatingContainer_${mode}`]}`}
+                    >
                       <StarRating rating={4.8} size={12.84} />
                     </div>
                     <p
-                      className={`${styles.RecommendContentRatingText} text-xs-regular`}
+                      className={`${styles.RecommendContentRatingText} ${styles[`RecommendContentRatingText_${mode}`]} text-xs-regular`}
                     >
                       Sentinel Carbernet Sauvignon 2016
                     </p>
@@ -59,7 +87,9 @@ const Wines: React.FC = () => {
             </div>
           </div>
         </div>
-        <div className={styles.custom_input_wrapper}>
+        <div
+          className={`${styles.custom_input_wrapper} ${styles[`custom_input_wrapper_${mode}`]}`}
+        >
           <Input
             type="search"
             icon="search"
@@ -67,61 +97,92 @@ const Wines: React.FC = () => {
             size="search"
           />
         </div>
-        <div className={styles.wines_list}>
-          <div className={styles.wines_listMapContainer}>
+        <div className={`${styles.wines_list} ${styles[`wines_list_${mode}`]}`}>
+          <div
+            className={`${styles.wines_listMapContainer} ${styles[`wines_listMapContainer_${mode}`]}`}
+          >
             {wineList.map((wine) => (
-              <div key={wine.id} className={styles.wines_listMap}>
-                <div className={styles.wines_lisMapDetailContainer}>
-                  <div className={styles.wines_listMapDetail}>
-                    <div className={styles.wines_listMapDetailImg}>
+              <div
+                key={wine.id}
+                className={`${styles.wines_listMap} ${styles[`wines_listMapContainer_${mode}`]}`}
+              >
+                <div
+                  className={`${styles.wines_listMapDetailContainer} ${styles[`wines_listMapDetailContainer_${mode}`]}`}
+                >
+                  <div
+                    className={`${styles.wines_listMapDetail} ${styles[`wines_listMapDetail_${mode}`]}`}
+                  >
+                    <div
+                      className={`${styles.wines_listMapDetailImg} ${styles[`wines_listMapDetailImg_${mode}`]}`}
+                    >
                       <img src={wine.image} alt="와인 이미지" />
                     </div>
-                    <div className={styles.wines_listMapDetailContnet}>
-                      <div className={styles.wines_listMapDetailContentData}>
-                        <div className={styles.ContentTitleAndFrom}>
+                    <div
+                      className={`${styles.wines_listMapDetailContent} ${styles[`wines_listMapDetailContent_${mode}`]}`}
+                    >
+                      <div
+                        className={`${styles.wines_listMapDetailContentData} ${styles[`wines_listMapDetailContentData_${mode}`]}`}
+                      >
+                        <div
+                          className={`${styles.ContentTitleAndFrom} ${styles[`ContentTitleAndFrom_${mode}`]}`}
+                        >
                           <div
-                            className={`${styles.ContentTitle} text-3xl-semibold`}
+                            className={`${styles.ContentTitle} ${styles[`ContentTitle_${mode}`]} text-3xl-semibold`}
                           >
                             {wine.name}
                           </div>
                           <div
-                            className={`${styles.ContentFrom} text-lg-regular`}
+                            className={`${styles.ContentFrom} ${styles[`ContentFrom_${mode}`]} text-lg-regular`}
                           >
                             {wine.origin}
                           </div>
                         </div>
-                        <div className={styles.ContentRating}>
-                          <p className={styles.ContentRatingNumber}>
+                        <div
+                          className={`${styles.ContentRating} ${styles[`ContentRaing_${mode}`]}`}
+                        >
+                          <p
+                            className={`${styles.ContentRatingNumber} ${styles[`ContentRaingNumber_${mode}`]}`}
+                          >
                             {wine.rating}
                           </p>
                           <StarRating rating={wine.rating} size={17.12} />
                           <p
-                            className={`${styles.ContentRatingTotal} text-md-regular`}
+                            className={`${styles.ContentRatingTotal} ${styles[`ContentRatingTotal_${mode}`]} text-md-regular`}
                           >
                             {wine.reviewCount}개 후기
                           </p>
                         </div>
                       </div>
-                      <div className={styles.wines_listMapDetailContentPrice}>
-                        <div className={`${styles.ContentPrice} text-xl-bold`}>
+                      <div
+                        className={`${styles.wines_listMapDetailContentPrice} ${styles[`wines_listMapDetailContentPrice_${mode}`]}`}
+                      >
+                        <div
+                          className={`${styles.ContentPrice} ${styles[`ContentPrice_${mode}`]} text-xl-bold`}
+                        >
                           ₩ {wine.price.toLocaleString()}
                         </div>
-                        <div className={styles.ContentPriceBtn}>
+                        <div
+                          className={`${styles.ContentPriceBtn} ${styles[`ContentPriceBtn_${mode}`]}`}
+                        >
                           <img src="/icons/priceBtn.svg" alt="가격 버튼" />
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
-                <div className={styles.wines_lisMapReviewContianer}>
-                  <div className={styles.wines_listMapReview}>
+                <div
+                  className={`${styles.wines_listMapReviewContianer} ${styles[`wines_listMapReviewContainer_${mode}`]}`}
+                >
+                  <div
+                    className={`${styles.wines_listMapReview} ${styles[`wines_listMapReview_${mode}`]}`}
+                  >
                     <p
-                      className={`${styles.wines_listMapReviewTitle} text-lg-semibold`}
+                      className={`${styles.wines_listMapReviewTitle} ${styles[`wines_listMapReviewTitle`]} text-lg-semibold`}
                     >
                       최신후기
                     </p>
                     <p
-                      className={`${styles.wines_listMapReviewContent} text-lg-regular`}
+                      className={`${styles.wines_listMapReviewContent} ${styles[`wines_listMapReviewContent`]} text-lg-regular`}
                     >
                       {wine.review}
                     </p>

--- a/pages/wines.tsx
+++ b/pages/wines.tsx
@@ -32,6 +32,20 @@ const Wines: React.FC = () => {
     },
   ];
 
+  const getStarRatingSize = () => {
+    if (mode === 'mobile') {
+      return 8.56; // 모바일일 때 크기
+    }
+    return 12.84; // 데스크탑과 테블릿일 때 기본 크기
+  };
+
+  const getStarRatingSize2 = () => {
+    if (mode === 'mobile') {
+      return 9.99; // 모바일일 때 크기
+    }
+    return 17.12; // 데스크탑과 테블릿일 때 기본 크기
+  };
+
   return (
     <>
       <Header />
@@ -67,14 +81,14 @@ const Wines: React.FC = () => {
                     className={`${styles.RecommendContentRating} ${styles[`RecommendContentRating_${mode}`]}`}
                   >
                     <p
-                      className={`${styles.RecommnedContentRaitingNumber} ${styles[`RecommendContentRatingNumber_${mode}`]}`}
+                      className={`${styles.RecommendContentRatingNumber} ${styles[`RecommendContentRatingNumber_${mode}`]}`}
                     >
                       4.8
                     </p>
                     <div
                       className={`${styles.starRatingContainer} ${styles[`starRatingContainer_${mode}`]}`}
                     >
-                      <StarRating rating={4.8} size={12.84} />
+                      <StarRating rating={4.8} size={getStarRatingSize()} />
                     </div>
                     <p
                       className={`${styles.RecommendContentRatingText} ${styles[`RecommendContentRatingText_${mode}`]} text-xs-regular`}
@@ -104,7 +118,7 @@ const Wines: React.FC = () => {
             {wineList.map((wine) => (
               <div
                 key={wine.id}
-                className={`${styles.wines_listMap} ${styles[`wines_listMapContainer_${mode}`]}`}
+                className={`${styles.wines_listMap} ${styles[`wines_listMap_${mode}`]}`}
               >
                 <div
                   className={`${styles.wines_listMapDetailContainer} ${styles[`wines_listMapDetailContainer_${mode}`]}`}
@@ -138,14 +152,17 @@ const Wines: React.FC = () => {
                           </div>
                         </div>
                         <div
-                          className={`${styles.ContentRating} ${styles[`ContentRaing_${mode}`]}`}
+                          className={`${styles.ContentRating} ${styles[`ContentRating_${mode}`]}`}
                         >
                           <p
-                            className={`${styles.ContentRatingNumber} ${styles[`ContentRaingNumber_${mode}`]}`}
+                            className={`${styles.ContentRatingNumber} ${styles[`ContentRatingNumber_${mode}`]}`}
                           >
                             {wine.rating}
                           </p>
-                          <StarRating rating={wine.rating} size={17.12} />
+                          <StarRating
+                            rating={wine.rating}
+                            size={getStarRatingSize2()}
+                          />
                           <p
                             className={`${styles.ContentRatingTotal} ${styles[`ContentRatingTotal_${mode}`]} text-md-regular`}
                           >
@@ -171,18 +188,18 @@ const Wines: React.FC = () => {
                   </div>
                 </div>
                 <div
-                  className={`${styles.wines_listMapReviewContianer} ${styles[`wines_listMapReviewContainer_${mode}`]}`}
+                  className={`${styles.wines_listMapReviewContainer} ${styles[`wines_listMapReviewContainer_${mode}`]}`}
                 >
                   <div
                     className={`${styles.wines_listMapReview} ${styles[`wines_listMapReview_${mode}`]}`}
                   >
                     <p
-                      className={`${styles.wines_listMapReviewTitle} ${styles[`wines_listMapReviewTitle`]} text-lg-semibold`}
+                      className={`${styles.wines_listMapReviewTitle} ${styles[`wines_listMapReviewTitle_${mode}`]} text-lg-semibold`}
                     >
                       최신후기
                     </p>
                     <p
-                      className={`${styles.wines_listMapReviewContent} ${styles[`wines_listMapReviewContent`]} text-lg-regular`}
+                      className={`${styles.wines_listMapReviewContent} ${styles[`wines_listMapReviewContent_${mode}`]} text-lg-regular`}
                     >
                       {wine.review}
                     </p>
@@ -192,7 +209,12 @@ const Wines: React.FC = () => {
             ))}
           </div>
         </div>
-        <div className={styles.winesFilter}></div>
+        <div
+          className={`${styles.winesFilter} ${styles[`winesFilter_${mode}`]}`}
+        ></div>
+        <div
+          className={`${styles.winesFilterBtn} ${styles[`winesFilterBtn_${mode}`]}`}
+        ></div>
       </div>
     </>
   );


### PR DESCRIPTION
## 작업내용 
- closes #44 
- 추가적인 CSS 작업과 
- useDevice를 통한 모바일, 테블릿 반응형 처리 작업을 완료 했습니다

## 테블릿 
<img width="500" alt="스크린샷 2025-02-13 오후 11 41 43" src="https://github.com/user-attachments/assets/35c492bc-b20a-428a-9f57-345ab136a541" />

## 모바일
<img width="457" alt="스크린샷 2025-02-13 오후 11 42 02" src="https://github.com/user-attachments/assets/caf9476c-968b-4ad4-8688-a1096af96896" />

## 내일 작업 예정 

- 이미지에 보이는 필터 부분을 구현하고, 슬라이드만 구현하면 wine-list 페이지도 api 작업 및 모달 연결작업만 하면 마칠 것 같습니다. 
- 내일은 필터와 슬라이드를 구현을 목표로 마치고
- 15일부터는 api작업을 시도하겠습니다.
